### PR TITLE
Update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@
 
 5. Give workflow permission:
 
-    You have to configure your repository -`Settings -> Action -> General -> Workflow permissions` and choose `Read and Write permissions`
+    On your repository `Settings -> Action -> General -> Workflow permissions` choose `Read and Write permissions`
 
 
     and you get:

--- a/README.md
+++ b/README.md
@@ -77,6 +77,11 @@
     + [![cov](https://we-cli.github.io/jayin/badges/coverage.svg)](https://github.com/we-cli/jayin/actions)
     ```
 
+5. Give workflow permission:
+
+    You have to configure your repository -`Settings -> Action -> General -> Workflow permissions` and choose `Read and Write permissions`
+
+
     and you get:
     
     [![cov](https://we-cli.github.io/coverage-badge-action/badges/coverage.svg)](https://github.com/we-cli/coverage-badge-action/actions)


### PR DESCRIPTION
To avoid this error on the GitHub action it is necessary to give a write permission.
fatal: unable to access 'https://github.com/xxx': The requested URL returned error: 403
