### PR TITLE
Set branch to gh-pages when committing

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -35,6 +35,7 @@ runs:
       uses: stefanzweifel/git-auto-commit-action@v4
       with:
         commit_message: "Update badges [skip ci]"
+        branch: gh-pages
         skip_fetch: true
         skip_checkout: true
 


### PR DESCRIPTION
This PR addresses an issue I experienced using this action. 

The action was failing because it was trying to commit the badge to my head branch (In my case it was `async-await`) instead of gh-pages. Here are screenshots of the issues.

![Screenshot 2023-05-30 at 9 55 50 AM](https://github.com/we-cli/coverage-badge-action/assets/52928432/8ed3fa5c-4c7b-40cb-8552-64ef2ddadc2f)

![Screenshot 2023-05-30 at 9 56 09 AM](https://github.com/we-cli/coverage-badge-action/assets/52928432/8365835d-f2ae-45c9-a58c-4300efc3a2bb)
