### PR TITLE
Upgrade actions/checkout to resolve compatibility issue with checkout@v6

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -4,10 +4,10 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
 
       - name: Set up Python 3.10
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v6
         with:
           python-version: "3.10"
 

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -2,6 +2,8 @@ name: Pytest
 on: [push, pull_request, workflow_dispatch]
 jobs:
   test:
+    permissions:
+      contents: write # Update Coverage Badge needs write permission to push to gh-pages
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,8 +4,8 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
 
       # Install and Test Example
       - name: Install and Test Example

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,8 @@ name: Test
 on: [push, pull_request, workflow_dispatch]
 jobs:
   test:
+    permissions:
+      contents: write # Update Coverage Badge needs write permission to push to gh-pages
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
 # .github/workflows/test.yml
 # ...
 - name: Set up Python 3.10
-  uses: actions/setup-python@v3
+  uses: actions/setup-python@v6
   with:
     python-version: "3.10"
 
@@ -85,8 +85,8 @@
         runs-on: ubuntu-latest
         steps:
           # Your original steps
-          - uses: actions/checkout@v3
-          - uses: actions/setup-node@v3
+          - uses: actions/checkout@v6
+          - uses: actions/setup-node@v6
           - name: Install
             run: npm install
           - name: Test and Coverage

--- a/action.yml
+++ b/action.yml
@@ -48,7 +48,7 @@ runs:
         fi
 
     - name: Checkout ${{ steps.pick-deploy-branch.outputs.deploy_branch }}
-      uses: actions/checkout@v3
+      uses: actions/checkout@v6
       with:
         ref: ${{ steps.pick-deploy-branch.outputs.deploy_branch }}
 
@@ -79,6 +79,6 @@ runs:
     # Can't find 'action.yml', 'action.yaml' or 'Dockerfile' under '/home/runner/work/coverage-badge-action/coverage-badge-action/action.yml'.
     # Did you forget to run actions/checkout before running your local action?
     - name: Checkout Back
-      uses: actions/checkout@v3
+      uses: actions/checkout@v6
       with:
         ref: ${{ github.ref }}


### PR DESCRIPTION
## Description

This PR upgrades the internal usage of `actions/checkout` (from v3) to resolve a critical compatibility issue when users use `actions/checkout@v6` in their parent workflow.

## The Issue

If a user utilizes `actions/checkout@v6` in their workflow, they may encounter the following error when this action runs:

> remote: Duplicate header: "Authorization"
Error: fatal: unable to access '...': The requested URL returned error: 400

This is caused by a conflict in how Git credentials are persisted between different versions of actions/checkout:
+ User Side (v6): As per [actions/checkout#2286](https://github.com/actions/checkout/pull/2286), newer versions of checkout persist credentials in a separate config file referencing `includeIf`, instead of modifying `.git/config` directly.
+ Action Side (v3): The current version in this action modifies the local `.git/config`.
+ Conflict: When git fetch/push is executed inside this action, both the global credential (from v6) and the local credential (from v3) are applied, resulting in two Authorization headers and a 400 Bad Request error from GitHub.

## Fix

Upgrading the internal action dependency aligns the credential management mechanism and prevents the "Double Auth" conflict. I have verified this fix in a forked version.